### PR TITLE
fix: problems with latest Go1.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Go tests
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE"
+  pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE"
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.22.x, 1.23.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - name: Run tests
+        run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/jcchavezs/mergefs
 
-go 1.16
+go 1.22
 
 require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/readfile.go
+++ b/readfile.go
@@ -20,10 +20,13 @@ func (rfs *readFileFS) ReadFile(name string) (content []byte, err error) {
 		if err == nil {
 			return content, nil
 		} else if !errors.Is(err, os.ErrNotExist) {
-			if errors.Unwrap(err).Error() != "invalid name" {
-				// invalid name is returned when the filename
-				// is an absolute path, which is only supported by
-				// the OS filesystem
+			// invalid name is returned when the filename
+			// is an absolute path, which is only supported by
+			// the OS filesystem.
+			// Starting from Go 1.23, os.ErrInvalid is used as error message.
+			// See go-review.googlesource.com/c/go/+/560137/4/src/io/fs/sub.go
+			// Both errors are checked to support both versions.
+			if errors.Unwrap(err).Error() != "invalid name" && !errors.Is(err, os.ErrInvalid) {
 				return nil, err
 			}
 		}

--- a/readfile_test.go
+++ b/readfile_test.go
@@ -56,7 +56,7 @@ func TestReadfile(t *testing.T) {
 var testdataFS embed.FS
 
 func TestAbsolutePath(t *testing.T) {
-	// Emulates github.com/corazawaf/coraza-coreruleset/blob/main/coreruleset.go usafe of mergefs
+	// Emulates github.com/corazawaf/coraza-coreruleset/blob/main/coreruleset.go usage of mergefs
 	rulesFS, err := fs.Sub(testdataFS, "testdata")
 	require.NoError(t, err)
 

--- a/readfile_test.go
+++ b/readfile_test.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"io/fs"
 	"os"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -55,7 +56,11 @@ func TestReadfile(t *testing.T) {
 var testdataFS embed.FS
 
 func TestAbsolutePath(t *testing.T) {
-	mfs := Merge(testdataFS, io.OSFS)
+	// Emulates github.com/corazawaf/coraza-coreruleset/blob/main/coreruleset.go usafe of mergefs
+	rulesFS, err := fs.Sub(testdataFS, "testdata")
+	require.NoError(t, err)
+
+	mfs := Merge(rulesFS, io.OSFS)
 
 	f, err := os.CreateTemp(t.TempDir(), "fizz.conf")
 	require.NoError(t, err)
@@ -71,4 +76,9 @@ func TestAbsolutePath(t *testing.T) {
 
 	_, err = rfmfs.ReadFile(f.Name())
 	require.NoError(t, err)
+
+	_, err = rfmfs.ReadFile("/tmp/doesnotexist.conf")
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("expected not found error. Got: %s", err.Error())
+	}
 }


### PR DESCRIPTION
With https://go-review.googlesource.com/c/go/+/560137/4/src/io/fs/sub.go#36, the returned error has been changed, therefore we are not able to match it anymore. We have not been able to spot the issue until users started upgrading Coraza connectors, therefore I'm adding tests on both this PR and Coraza main PR.

Issue described: https://github.com/corazawaf/coraza/issues/1208
Coraza PR that adds a test: https://github.com/corazawaf/coraza/pull/1211
