### PR TITLE
fix: sort ReadDir result

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"sort"
 )
 
 // Merge filesystems
@@ -119,6 +120,9 @@ func (mfs mergedFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	for _, value := range dirsMap {
 		dirs = append(dirs, value)
 	}
+	sort.Slice(dirs, func(i, j int) bool {
+		return dirs[i].Name() < dirs[j].Name()
+	})
 
 	return dirs, nil
 }

--- a/merge_test.go
+++ b/merge_test.go
@@ -123,7 +123,6 @@ func TestReadDirIsSorted(t *testing.T) {
 		"dir/1": &fstest.MapFile{Mode: fs.ModeDir},
 	}
 
-
 	mfs := mergefs.Merge(fs1, fs2, fs3)
 	entries, err := fs.ReadDir(mfs, "dir")
 	require.NoError(t, err)

--- a/merge_test.go
+++ b/merge_test.go
@@ -104,3 +104,34 @@ func TestMergedOpen(t *testing.T) {
 
 	require.NoError(t, file.Close())
 }
+
+func TestReadDirIsSorted(t *testing.T) {
+	fs1 := fstest.MapFS{
+		"dir":   &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/b": &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/a": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+	fs2 := fstest.MapFS{
+		"dir":   &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/d": &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/c": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+	fs3 := fstest.MapFS{
+		"dir":   &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/3": &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/2": &fstest.MapFile{Mode: fs.ModeDir},
+		"dir/1": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+
+
+	mfs := mergefs.Merge(fs1, fs2, fs3)
+	entries, err := fs.ReadDir(mfs, "dir")
+	require.NoError(t, err)
+
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name()
+	}
+
+	require.Equal(t, []string{"1", "2", "3", "a", "b", "c", "d"}, names)
+}


### PR DESCRIPTION
Adds sorting for `ReadDir` results.

Closes #2